### PR TITLE
Fixes for README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 # production
 /build
 
+# SlashDB config and log files
+/slashdb
+/slashdb-log
+
 # misc
 .DS_Store
 .env.local

--- a/README.md
+++ b/README.md
@@ -169,19 +169,27 @@ Then open a browser and navigate to http://localhost:3000/
         ls slashdb
         auth.cfg  databases.cfg  license.key  nginx.conf  querydefs.cfg  slashdb.ini  taskdatadb.sqlite  users.cfg
 
-7.  Navigate to folder slashdb and run command:
+7.  Create folder for **SlashDB** logs.
+
+        mkdir slashdb-log
+
+8.  Create **SlashDB** docker container:
 
    Linux:
 
          docker run -d -p 8000:80 -v $(pwd):/etc/slashdb -v $(pwd):/var/log/slashdb slashdb/slashdb
 
-   Windows:
+   Windows (PowerShell):
 
-         docker run -d -p 8000:80 -v C:\Current\TestLocalWithConfic\slashdb:/etc/slashdb -v C:\Current\TestLocalWithConfic\slashdb:/var/log/slashdb slashdb/slashdb
+         docker run -d -p 8000:80 -v $pwd/slashdb:/etc/slashdb -v $pwd/slashdb-log:/var/log/slashdb slashdb/slashdb
 
-8.  In your browser, go to http://localhost:8000 to finish the initialization process. For more details see the [video](https://www.youtube.com/watch?v=XLqTX0XHXNI) and [SlashDB Documentation](https://docs.slashdb.com/user-guide/configuration.html)
+   Windows (Command Prompt):
 
-9.  Browse task app data at http://localhost:8000/db/taskdatadb.html. You can find more on how to use SlashDB API at https://docs.slashdb.com/user-guide/using-slashdb.html
+         docker run -d -p 8000:80 -v %cd%/slashdb:/etc/slashdb -v %cd%/slashdb-log:/var/log/slashdb slashdb/slashdb
+
+9.  In your browser, go to http://localhost:8000 to finish the initialization process. For more details see the [video](https://www.youtube.com/watch?v=XLqTX0XHXNI) and [SlashDB Documentation](https://docs.slashdb.com/user-guide/configuration.html)
+
+10.  Browse task app data at http://localhost:8000/db/taskdatadb.html. You can find more on how to use SlashDB API at https://docs.slashdb.com/user-guide/using-slashdb.html
 
 ![Server view](https://user-images.githubusercontent.com/807888/132827985-7813ebc9-9adf-4418-a369-fc1684995882.png 'Server view')
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Then open a browser and navigate to http://localhost:3000/
 
    Linux:
 
-         docker run -d -p 8000:80 -v $(pwd):/etc/slashdb -v $(pwd):/var/log/slashdb slashdb/slashdb
+         docker run -d -p 8000:80 -v $(pwd)/slashdb:/etc/slashdb -v $(pwd)/slashdb-log:/var/log/slashdb slashdb/slashdb
 
    Windows (PowerShell):
 

--- a/data/users.cfg
+++ b/data/users.cfg
@@ -1,5 +1,5 @@
 admin:
-  api_key: 6bx2gebsv1p6mb6sjtpibsu6dfzvz1rv
+  api_key: null
   creator: admin
   databases:
     Chinook:
@@ -9,10 +9,10 @@ admin:
       dbpass: ''
       dbuser: ''
   dbdef: []
-  edit: []
+  edit: [admin]
   email: ''
   name: Default administrator with full permissions
-  password: $6$rounds=656000$CXrRZ7OBFg1pfK8B$Px5aCDoA1okyPWBa2mtKfqTidFDdPuE3XwrGp9X5uDW2GAsTiMl0Mnr1rpXhWndWejV0whZwKpJFyRRUFxnmM/
+  password: admin
   querydef: []
   user_id: admin
   userdef: []


### PR DESCRIPTION
Two main important fixes to the readme file.

Command to create docker container improved to work on both Linux and Windows.
Create a different directory for logs, this way it has the same tree structure for volumes accordingly with the official [SlashDB docs](https://docs.slashdb.com/user-guide/getting-slashdb/docker/)

Folders
- slashdb
- slashdb-log

Created for docker container volumes added to git ignore file

**users.cfg** file inside **data** directory updated to set default values for admin user